### PR TITLE
Add a default User Agent with customizable argument

### DIFF
--- a/upodder/upodder.py
+++ b/upodder/upodder.py
@@ -36,6 +36,8 @@ parser.add_argument('--import-opml', '-i', dest='opmlpath',
     help='Import feeds from an OPML file.')
 parser.add_argument("--quiet", help="Only output errors.",
                     action="store_true")
+parser.add_argument('--user-agent', '-A', default='upodder',
+    help="Set custom User-Agent string.")
 args = parser.parse_args()
 
 YES = [1,"1","on","yes","Yes","YES","y","Y","true","True","TRUE","t","T"]
@@ -117,7 +119,9 @@ class EntryProcessor(object):
                 os.makedirs(os.path.dirname(downloadto))
 
             l.debug("Downloading %s from %s" % (entry['title'], enclosure['href']))
-            r = requests.get(enclosure['href'], stream=True, timeout=25)
+
+            headers = { 'User-Agent': args.user_agent }
+            r = requests.get(enclosure['href'], stream=True, timeout=25, headers=headers)
 
             with open(downloadto, 'wb') as f:
                 if 'content-length' in r.headers:


### PR DESCRIPTION
Setting a default user agent makes it easier to identify who/what is making requests to a feed. 

I reviewed the codebase but couldn’t locate an implementation for #2, which was marked as completed. Please let me know if I missed any related changes. Thanks!